### PR TITLE
fix puppet launch option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { Transform } = require('stream')
 const { inherits } = require('util')
-const { launch } = require('puppeteer')
+const puppeteer = require('puppeteer')
 const finished = require('tap-finished')
 const pump = require('pump')
 
@@ -46,7 +46,7 @@ TapePuppetStream.prototype._flush = async function flush (end) {
 
   var browser, page
   try {
-    browser = await launch(self._opts)
+    browser = await puppeteer.launch(self._opts)
     page = (await browser.pages())[0]
   } catch (err) {
     return await shutdown(err)


### PR DESCRIPTION
When I created a hello world test example from my machine, I noticed the following error

```
> browserify worker.test.js | tape-puppet

TypeError: Cannot read property '_launcher' of undefined
    at launch (/Users/fraserxu/src/.../node_modules/puppeteer/lib/Puppeteer.js:41:17)
    at TapePuppetStream.flush [as _flush] (/Users/fraserxu/src/.../node_modules/tape-puppet/index.js:49:21)
    at TapePuppetStream.prefinish (_stream_transform.js:137:10)
    at emitNone (events.js:106:13)
    at TapePuppetStream.emit (events.js:208:7)
    at prefinish (_stream_writable.js:593:14)
    at finishMaybe (_stream_writable.js:601:5)
    at endWritable (_stream_writable.js:612:3)
    at TapePuppetStream.Writable.end (_stream_writable.js:563:5)
    at Socket.onend (_stream_readable.js:595:10)
```

This seems related to the `launch` from `puppeteer` is a `Class` now https://github.com/GoogleChrome/puppeteer/blob/master/lib/Puppeteer.js#L35

So instead of `const {launch} = require('puppeteer')`, we need to call `puppeteer.launch`.

The test works fine after this change.

